### PR TITLE
Make GitHub classify .scn files as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.scn linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this if you'd like GitHub to show your .scn files as Forth.

Best regards,
Lars Brinkhoff